### PR TITLE
Issue #7

### DIFF
--- a/app/config/config.yml
+++ b/app/config/config.yml
@@ -66,7 +66,10 @@ services:
        class: Twig_Extensions_Extension_Text
        tags:
            - { name: twig.extension }
-
+   sfm.twig.extension:
+       class: SFM\WebsiteBundle\Extension\SFMTwigExtension
+       tags:
+           - { name: twig.extension }
 
 nekland_feed:
     feeds:

--- a/src/SFM/WebsiteBundle/Controller/DefaultController.php
+++ b/src/SFM/WebsiteBundle/Controller/DefaultController.php
@@ -20,7 +20,8 @@ class DefaultController extends Controller {
      * @return array
      * @Route("/", name="home")
      */
-    public function indexAction() {
+    public function indexAction()
+    {
         $em = $this->getDoctrine()->getEntityManager();
         $nextEvent = $em->getRepository('SFMWebsiteBundle:Event')->getNextEvent();
         $sfm = $this->get('sfm.feed_generator')->generateEventsFeed();
@@ -28,12 +29,12 @@ class DefaultController extends Controller {
         $response = $this->render('SFMWebsiteBundle:Default:index.html.twig', array(
             'current' => 'home',
             'nextEvent' => $nextEvent,
-                ));        
+                ));
         $response->setExpires(new \DateTime('now + 15 minutes'));
         $response->setMaxAge(15 * 60);
-        
-        return $response;       
-        
+
+        return $response;
+
     }
 
     /**
@@ -43,7 +44,8 @@ class DefaultController extends Controller {
      * @Route("/acerca-de", name="about")
      * @Template()
      */
-    public function aboutAction() {
+    public function aboutAction()
+    {
         /**
          * Better a random order than alphabetical :)
          */
@@ -70,7 +72,8 @@ class DefaultController extends Controller {
      * @Method("get")
      * @Template()
      */
-    public function contactAction() {
+    public function contactAction()
+    {
         return array(
             'current' => 'contact',
         );
@@ -84,7 +87,8 @@ class DefaultController extends Controller {
      * @Method("post")
      * @Template()
      */
-    public function sendMailAction() {
+    public function sendMailAction()
+    {
         $contactData = array(
             'nombre' => $this->getRequest()->get('nombre'),
             'email' => $this->getRequest()->get('email'),
@@ -116,7 +120,8 @@ class DefaultController extends Controller {
      *
      * @param array $contactData Data given from contact form.
      */
-    private function sendMailOnContactFormSuccess(Array $contactData) {
+    private function sendMailOnContactFormSuccess(Array $contactData)
+    {
         $mailTo = $this->container->getParameter('contactmail');
 
         $message = \Swift_Message::newInstance()
@@ -134,7 +139,8 @@ class DefaultController extends Controller {
      * @param array $contactData
      * @throws \Symfony\Component\HttpKernel\Exception\HttpException
      */
-    private function validateContactData(array $contactData) {
+    private function validateContactData(array $contactData)
+    {
         $collectionConstraint = new Collection(array(
                     'nombre' => array(
                         new NotBlank()
@@ -154,7 +160,8 @@ class DefaultController extends Controller {
         }
     }
 
-    private function parseErrors($errors) {
+    private function parseErrors($errors)
+    {
 
         $translator = $this->container->get('translator');
         $parsedErrors = array();

--- a/src/SFM/WebsiteBundle/Controller/WidgetsController.php
+++ b/src/SFM/WebsiteBundle/Controller/WidgetsController.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace SFM\WebsiteBundle\Controller;
+
+use Symfony\Bundle\FrameworkBundle\Controller\Controller;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Route;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Method;
+use Symfony\Component\HttpFoundation\Response;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Template;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+class WidgetsController extends Controller {
+
+    /**
+     * Google group widget
+     *
+     * @return Response
+     *
+     * @Template("SFMWebsiteBundle:Widgets:google-group.html.twig")
+     * @Route("/widgets/google-group", name="widgets_google_group")
+     */
+    public function googleGroupAction()
+    {
+        $ch = curl_init();
+        curl_setopt($ch, CURLOPT_URL, 'https://groups.google.com/group/symfony_madrid/feed/rss_v2_0_topics.xml');
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+        $feed = new \SimpleXMLElement(curl_exec($ch));
+
+        curl_close($ch);
+
+        return array('feed' => $feed);
+
+    }
+}

--- a/src/SFM/WebsiteBundle/DependencyInjection/Extension.php
+++ b/src/SFM/WebsiteBundle/DependencyInjection/Extension.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace SFM\WebsiteBundle\DependencyInjection;
+
+use Symfony\Component\HttpKernel\DependencyInjection\Extension;
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Definition;
+
+class TwigExtension extends Extension
+{
+    public function load(array $config, ContainerBuilder $container)
+    {
+        $definition = new Definition('SFM\WebsiteBundle\Extension\SFMTwigExtension');
+        $definition->addTag('twig.extension');
+        $container->setDefinition('sfm_twig_extension', $definition);
+    }
+}

--- a/src/SFM/WebsiteBundle/Extension/SFMTwigExtension.php
+++ b/src/SFM/WebsiteBundle/Extension/SFMTwigExtension.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace SFM\WebsiteBundle\Extension;
+
+/**
+ * TwigExtension
+ *
+ * @author Eduardo Gulias Davis <me@egulias.com>
+ *
+ */
+class SFMTwigExtension extends \Twig_Extension
+{
+    /**
+     * getFilters
+     *
+     * @return array()
+     */
+    public function getFilters()
+    {
+        return array(
+          'split'  => new \Twig_Filter_Method($this, 'split'),
+        );
+    }
+
+    /**
+     * split
+     *
+     * @param string $sentence
+     *
+     * @param string $expr
+     *
+     * @return array
+     */
+    public function split($sentence, $expr)
+    {
+        return explode($expr, $sentence);
+    }
+
+    /**
+     * getName
+     *
+     * @return string
+     */
+    public function getName()
+    {
+        return 'sfm_twig_extension';
+    }
+}

--- a/src/SFM/WebsiteBundle/Resources/views/Widgets/google-group.html.twig
+++ b/src/SFM/WebsiteBundle/Resources/views/Widgets/google-group.html.twig
@@ -1,0 +1,12 @@
+<div>
+<ul>
+{% for thread in feed.channel.item %}
+  <li><a href="{{thread.link}}">{{thread.title}}</a>
+    <ul>
+      <li>{{thread.author}}</li>
+      <li>{{thread.pubDate}}</li>
+    </ul>
+  </li>
+{% endfor %}
+</ul>
+</div>

--- a/src/SFM/WebsiteBundle/Resources/views/Widgets/google-group.html.twig
+++ b/src/SFM/WebsiteBundle/Resources/views/Widgets/google-group.html.twig
@@ -1,12 +1,14 @@
 <div>
 <ul>
 {% for thread in feed.channel.item %}
-  <li><a href="{{thread.link}}">{{thread.title}}</a>
-    <ul>
-      <li>{{thread.author}}</li>
-      <li>{{thread.pubDate}}</li>
-    </ul>
-  </li>
+  {% if loop.index < 6 %}
+    <li><a href="{{thread.link}}">{{thread.title}}</a>
+      <ul>
+        <li>{{thread.author}}</li>
+        <li>{{thread.pubDate}}</li>
+      </ul>
+    </li>
+  {%endif%}
 {% endfor %}
 </ul>
 </div>

--- a/src/SFM/WebsiteBundle/Resources/views/Widgets/google-group.html.twig
+++ b/src/SFM/WebsiteBundle/Resources/views/Widgets/google-group.html.twig
@@ -4,8 +4,15 @@
   {% if loop.index < 6 %}
     <li><a href="{{thread.link}}">{{thread.title}}</a>
       <ul>
-        <li>{{thread.author}}</li>
-        <li>{{thread.pubDate}}</li>
+        <li>por
+          {% set author = thread.author | split('(')%}
+          {% set author = author[1] | split(')') %}
+          {{author[0]}}
+        </li>
+        <li>
+          {% set created = thread.pubDate | split(' UT')%}
+          el {{created[0] | date('d/m/Y', 'UTC')}}
+        </li>
       </ul>
     </li>
   {%endif%}


### PR DESCRIPTION
Hola!
Este pull request soluciona la #7 que puso Oscar.
Incluye una extensión de Twig para "explode" (afecta al confiy.yml).

He creado un controlador de widgets y he incluido uno para "google groups". De esta forma podemos gestionar todos los widgets desde aqui.

Para usarlo basta con poner {% render "SFMWebsiteBundle:Widgets:googleGroup"%} en donde se quiera. Esto mostrará una lista de los últimos 5 threads del grupo con creador y fecha de creación. Para ello tira de una plantilla muy básica... aquí es turno de alguien con mano para el diseño. Pintantolo directamente como lista no queda tan mal, lo probé en local.

El pull request es para dev, probarla allí y si tira, ya sabéis :)

Ya me contais.
